### PR TITLE
:seedling: Initial PoC of pass-through fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.o
+config/*
+cntlm
+
+configure-stamp

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: c

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-#
+
 # You can tweak these three variables to make things install where you
 # like, but do not touch more unless you know what you are doing. ;)
 #
@@ -127,3 +127,8 @@ distclean: clean
 		fakeroot rpm/rules clean; \
 	fi
 	@rm -f *.exe *.deb *.rpm *.tgz *.tar.gz *.tar.bz2 tags ctags pid 2>/dev/null
+
+# There are no tests, this is added to travis CI can at least confirm
+# compilation occurred
+test:	$(NAME)
+  


### PR DESCRIPTION
This feature aims to implement a simple recovery option for when the
configured proxy list is unreachable.

- Adds two configuration options (**NB: these are subject to change!**)
  - `FallbackEnable` default:`false`

    Enables the fallback behaviour, namely when the proxy
    list has been exhausted and fails to connect - fall back on the
    same handler used for `NoProxy`
  - `FallbackRetryRate` default:`10`

    How frequently to re-poll for proxy connectivity.

    Note that this doesn't set up a timer thread, and is presently only re-checking
    whenever a new request comes through and the time has passed.

    The hope is this approach will minimise unnecessary socket spam, however more
    extensive testing is needed to validate this approach